### PR TITLE
Edit Plan

### DIFF
--- a/src/Components/Pages/dashboard/EditPlan.jsx
+++ b/src/Components/Pages/dashboard/EditPlan.jsx
@@ -1,7 +1,23 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
 import { Box, Typography, FormControl, FormLabel, TextField, Button } from "@mui/material";
+import { getPlan } from "../../../util/dashboard";
 
 function EditPlan() {
+  const [plan, setPlan] = useState({});
+  const [error, setError] = useState(null);
+  const { planId } = useParams();
+
+  useEffect(() => {
+    if (!planId) return;
+
+    (async () => {
+      const data = await getPlan(planId, setError);
+      if (!data) return;
+      setPlan(data);
+    })();
+  }, []);
+
   return (
     <>
       <Box sx={{ marginBottom: 2 }}>
@@ -18,6 +34,7 @@ function EditPlan() {
             variant="outlined"
             fullWidth
             placeholder="Enter the title of your plan"
+            value={plan.title || ""}
           />
         </FormControl>
 
@@ -31,6 +48,7 @@ function EditPlan() {
             variant="outlined"
             fullWidth
             placeholder="Select a category for your plan"
+            value={plan?.categoryId?._id || ""}
           />
         </FormControl>
 
@@ -45,6 +63,7 @@ function EditPlan() {
             multiline
             placeholder="Write a brief description of your plan"
             minRows={4}
+            value={plan.description || ""}
           />
         </FormControl>
         <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>

--- a/src/Components/Pages/dashboard/EditPlan.jsx
+++ b/src/Components/Pages/dashboard/EditPlan.jsx
@@ -1,7 +1,59 @@
 import React from "react";
+import { Box, Typography, FormControl, FormLabel, TextField, Button } from "@mui/material";
 
 function EditPlan() {
-  return <div>Edit Plan Component</div>;
+  return (
+    <>
+      <Box sx={{ marginBottom: 2 }}>
+        <Typography variant="h4">Edit Plan:</Typography>
+      </Box>
+      <Box sx={{ width: "100%", maxWidth: 650 }}>
+      
+        {/* Title */}
+        <FormControl fullWidth margin="normal">
+          <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+            Title
+          </FormLabel>
+          <TextField
+            variant="outlined"
+            fullWidth
+            placeholder="Enter the title of your plan"
+          />
+        </FormControl>
+
+        {/* Category */}
+        {/* TODO: Replace it with a select dropdown */}
+        <FormControl fullWidth margin="normal">
+          <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+            Category
+          </FormLabel>
+          <TextField
+            variant="outlined"
+            fullWidth
+            placeholder="Select a category for your plan"
+          />
+        </FormControl>
+
+        {/* Description */}
+        <FormControl fullWidth margin="normal">
+          <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+            Description
+          </FormLabel>
+          <TextField
+            variant="outlined"
+            fullWidth
+            multiline
+            placeholder="Write a brief description of your plan"
+            minRows={4}
+          />
+        </FormControl>
+        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
+          <Button variant="outlined" sx={{ backgroundColor: "white", color: "#4CAF50", borderColor: "#4CAF50", ":hover": { backgroundColor: "#388e3c30", borderColor: "#388e3c"} }}>Cancel</Button>
+          <Button variant="contained" color="primary">Publish</Button>
+        </Box>
+      </Box>
+    </>
+  );
 }
 
 export default EditPlan;

--- a/src/Components/Pages/dashboard/EditPlan.jsx
+++ b/src/Components/Pages/dashboard/EditPlan.jsx
@@ -7,30 +7,38 @@ import {
   FormLabel,
   TextField,
   Button,
+  Select,
+  MenuItem,
 } from "@mui/material";
-import { getPlan, updatePlan } from "../../../util/dashboard";
+import { getPlan, updatePlan, getCategories } from "../../../util/dashboard";
 
 function EditPlan() {
   const [plan, setPlan] = useState({});
   const [error, setError] = useState(null);
   const { planId } = useParams();
   const navigate = useNavigate();
+  const [categories, setCategories] = useState([]);
 
   useEffect(() => {
     if (!planId) return;
 
     (async () => {
       const data = await getPlan(planId, setError);
-      if (!data) return;
+      const categoriesData = await getCategories(setError);
+
+      if (!data || !categoriesData) return;
+
       setPlan({
         ...data,
         categoryId: data.categoryId?._id,
         userId: data.userId?._id,
       });
+      setCategories(categoriesData);
     })();
   }, []);
 
-  const handleUpdate = async () => {
+  const handleUpdate = async (e) => {
+    e.preventDefault();
     const result = await updatePlan(plan, setError);
     if (!result) return;
 
@@ -44,70 +52,81 @@ function EditPlan() {
       </Box>
       <Box sx={{ width: "100%", maxWidth: 650 }}>
         {error && <p>{error}</p>}
+        <form onSubmit={handleUpdate}>
+          {/* Title */}
+          <FormControl fullWidth margin="normal">
+            <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+              Title *
+            </FormLabel>
+            <TextField
+              required
+              variant="outlined"
+              fullWidth
+              placeholder="Enter the title of your plan"
+              value={plan.title || ""}
+              onChange={(e) => setPlan({ ...plan, title: e.target.value })}
+            />
+          </FormControl>
 
-        {/* Title */}
-        <FormControl fullWidth margin="normal">
-          <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
-            Title
-          </FormLabel>
-          <TextField
-            variant="outlined"
-            fullWidth
-            placeholder="Enter the title of your plan"
-            value={plan.title || ""}
-            onChange={(e) => setPlan({ ...plan, title: e.target.value })}
-          />
-        </FormControl>
+          {/* Category */}
+          {/* TODO: Replace it with a select dropdown */}
+          <FormControl fullWidth margin="normal">
+            <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+              Category *
+            </FormLabel>
+            <Select
+              required
+              variant="outlined"
+              fullWidth
+              value={plan.categoryId || ""}
+              onChange={(e) => setPlan({ ...plan, categoryId: e.target.value })}
+            >
+              <MenuItem value="">Select a category</MenuItem>
+              {categories.map((category) => (
+                <MenuItem key={category._id} value={category._id}>
+                  {category.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
 
-        {/* Category */}
-        {/* TODO: Replace it with a select dropdown */}
-        <FormControl fullWidth margin="normal">
-          <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
-            Category
-          </FormLabel>
-          <TextField
-            variant="outlined"
-            fullWidth
-            placeholder="Select a category for your plan"
-            value={plan.categoryId || ""}
-            onChange={(e) => setPlan({ ...plan, categoryId: e.target.value })}
-          />
-        </FormControl>
-
-        {/* Description */}
-        <FormControl fullWidth margin="normal">
-          <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
-            Description
-          </FormLabel>
-          <TextField
-            variant="outlined"
-            fullWidth
-            multiline
-            placeholder="Write a brief description of your plan"
-            minRows={4}
-            value={plan.description || ""}
-            onChange={(e) => setPlan({ ...plan, description: e.target.value })}
-          />
-        </FormControl>
-        <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
-          <Button
-            variant="outlined"
-            sx={{
-              backgroundColor: "white",
-              color: "#4CAF50",
-              borderColor: "#4CAF50",
-              ":hover": {
-                backgroundColor: "#388e3c30",
-                borderColor: "#388e3c",
-              },
-            }}
-          >
-            Cancel
-          </Button>
-          <Button variant="contained" color="primary" onClick={handleUpdate}>
-            Save Changes
-          </Button>
-        </Box>
+          {/* Description */}
+          <FormControl fullWidth margin="normal">
+            <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+              Description *
+            </FormLabel>
+            <TextField
+              required
+              variant="outlined"
+              fullWidth
+              multiline
+              placeholder="Write a brief description of your plan"
+              minRows={4}
+              value={plan.description || ""}
+              onChange={(e) => setPlan({ ...plan, description: e.target.value })}
+            />
+          </FormControl>
+          <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
+            <Button
+              variant="outlined"
+              sx={{
+                backgroundColor: "white",
+                color: "#4CAF50",
+                borderColor: "#4CAF50",
+                ":hover": {
+                  backgroundColor: "#388e3c30",
+                  borderColor: "#388e3c",
+                },
+              }}
+              onClick={() => navigate("/account")}
+            >
+              Cancel
+            </Button>
+            <Button variant="contained" color="primary" type="submit">
+              Save Changes
+            </Button>
+          </Box>
+        </form>
       </Box>
     </>
   );

--- a/src/Components/Pages/dashboard/EditPlan.jsx
+++ b/src/Components/Pages/dashboard/EditPlan.jsx
@@ -1,6 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Box, Typography, FormControl, FormLabel, TextField, Button } from "@mui/material";
+import {
+  Box,
+  Typography,
+  FormControl,
+  FormLabel,
+  TextField,
+  Button,
+} from "@mui/material";
 import { getPlan, updatePlan } from "../../../util/dashboard";
 
 function EditPlan() {
@@ -15,7 +22,11 @@ function EditPlan() {
     (async () => {
       const data = await getPlan(planId, setError);
       if (!data) return;
-      setPlan({...data, categoryId: data.categoryId?._id, userId: data.userId?._id});
+      setPlan({
+        ...data,
+        categoryId: data.categoryId?._id,
+        userId: data.userId?._id,
+      });
     })();
   }, []);
 
@@ -32,7 +43,6 @@ function EditPlan() {
         <Typography variant="h4">Edit Plan:</Typography>
       </Box>
       <Box sx={{ width: "100%", maxWidth: 650 }}>
-
         {error && <p>{error}</p>}
 
         {/* Title */}
@@ -80,8 +90,23 @@ function EditPlan() {
           />
         </FormControl>
         <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
-          <Button variant="outlined" sx={{ backgroundColor: "white", color: "#4CAF50", borderColor: "#4CAF50", ":hover": { backgroundColor: "#388e3c30", borderColor: "#388e3c"} }}>Cancel</Button>
-          <Button variant="contained" color="primary" onClick={handleUpdate}>Save Changes</Button>
+          <Button
+            variant="outlined"
+            sx={{
+              backgroundColor: "white",
+              color: "#4CAF50",
+              borderColor: "#4CAF50",
+              ":hover": {
+                backgroundColor: "#388e3c30",
+                borderColor: "#388e3c",
+              },
+            }}
+          >
+            Cancel
+          </Button>
+          <Button variant="contained" color="primary" onClick={handleUpdate}>
+            Save Changes
+          </Button>
         </Box>
       </Box>
     </>

--- a/src/Components/Pages/dashboard/EditPlan.jsx
+++ b/src/Components/Pages/dashboard/EditPlan.jsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { Box, Typography, FormControl, FormLabel, TextField, Button } from "@mui/material";
-import { getPlan } from "../../../util/dashboard";
+import { getPlan, updatePlan } from "../../../util/dashboard";
 
 function EditPlan() {
   const [plan, setPlan] = useState({});
   const [error, setError] = useState(null);
   const { planId } = useParams();
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!planId) return;
@@ -14,9 +15,16 @@ function EditPlan() {
     (async () => {
       const data = await getPlan(planId, setError);
       if (!data) return;
-      setPlan(data);
+      setPlan({...data, categoryId: data.categoryId?._id, userId: data.userId?._id});
     })();
   }, []);
+
+  const handleUpdate = async () => {
+    const result = await updatePlan(plan, setError);
+    if (!result) return;
+
+    navigate("/account");
+  };
 
   return (
     <>
@@ -37,6 +45,7 @@ function EditPlan() {
             fullWidth
             placeholder="Enter the title of your plan"
             value={plan.title || ""}
+            onChange={(e) => setPlan({ ...plan, title: e.target.value })}
           />
         </FormControl>
 
@@ -50,7 +59,8 @@ function EditPlan() {
             variant="outlined"
             fullWidth
             placeholder="Select a category for your plan"
-            value={plan?.categoryId?._id || ""}
+            value={plan.categoryId || ""}
+            onChange={(e) => setPlan({ ...plan, categoryId: e.target.value })}
           />
         </FormControl>
 
@@ -66,11 +76,12 @@ function EditPlan() {
             placeholder="Write a brief description of your plan"
             minRows={4}
             value={plan.description || ""}
+            onChange={(e) => setPlan({ ...plan, description: e.target.value })}
           />
         </FormControl>
         <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
           <Button variant="outlined" sx={{ backgroundColor: "white", color: "#4CAF50", borderColor: "#4CAF50", ":hover": { backgroundColor: "#388e3c30", borderColor: "#388e3c"} }}>Cancel</Button>
-          <Button variant="contained" color="primary">Publish</Button>
+          <Button variant="contained" color="primary" onClick={handleUpdate}>Save Changes</Button>
         </Box>
       </Box>
     </>

--- a/src/Components/Pages/dashboard/EditPlan.jsx
+++ b/src/Components/Pages/dashboard/EditPlan.jsx
@@ -103,7 +103,9 @@ function EditPlan() {
               placeholder="Write a brief description of your plan"
               minRows={4}
               value={plan.description || ""}
-              onChange={(e) => setPlan({ ...plan, description: e.target.value })}
+              onChange={(e) =>
+                setPlan({ ...plan, description: e.target.value })
+              }
             />
           </FormControl>
           <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>

--- a/src/Components/Pages/dashboard/EditPlan.jsx
+++ b/src/Components/Pages/dashboard/EditPlan.jsx
@@ -24,7 +24,9 @@ function EditPlan() {
         <Typography variant="h4">Edit Plan:</Typography>
       </Box>
       <Box sx={{ width: "100%", maxWidth: 650 }}>
-      
+
+        {error && <p>{error}</p>}
+
         {/* Title */}
         <FormControl fullWidth margin="normal">
           <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>

--- a/src/Components/Pages/dashboard/MyPlans.jsx
+++ b/src/Components/Pages/dashboard/MyPlans.jsx
@@ -8,7 +8,7 @@ import AlertDialog from "../../Common/AlertDialog";
 function MyPlans() {
   const [plans, setPlans] = useState([]);
   const [error, setError] = useState(null);
-  const [alertOpen, setAlertOpen] = React.useState(false);
+  const [alertOpen, setAlertOpen] = useState(false);
   const [selectedPlanToRemove, setSelectedPlanToRemove] = useState(null);
 
   useEffect(() => {

--- a/src/theme.jsx
+++ b/src/theme.jsx
@@ -45,7 +45,9 @@ const theme = createTheme({
       styleOverrides: {
         root: {
           fontSize: "0.85rem",
-          height: "38px",
+          "& input": {
+            padding: "12px 14px",
+          },
           "& .MuiOutlinedInput-notchedOutline": {
             borderColor: "#BDBDBD",
             borderWidth: "1px",

--- a/src/util/dashboard.js
+++ b/src/util/dashboard.js
@@ -87,7 +87,7 @@ const getCategories = async (onError) => {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
-      }
+      },
     });
     if (!res.ok) {
       const errorData = await res.json();
@@ -95,11 +95,10 @@ const getCategories = async (onError) => {
       return null;
     }
     return await res.json();
-  }
-  catch (error) {
+  } catch (error) {
     onError(error.message || "An error occurred while fetching categories");
     return null;
   }
-}
+};
 
 export { getMyPlans, deletePlan, getPlan, updatePlan, getCategories };

--- a/src/util/dashboard.js
+++ b/src/util/dashboard.js
@@ -40,4 +40,23 @@ const deletePlan = async (planId, onError) => {
   }
 };
 
-export { getMyPlans, deletePlan };
+const getPlan = async (planId, onError) => {
+  try {
+    let res = await fetch(`/api/v1/account/plans/${planId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!res.ok) {
+      const errorData = await res.json();
+      onError(errorData.msg || "Failed to fetch plan");
+      return null;
+    }
+    return await res.json();
+  } catch (error) {
+    onError(error.message || "An error occurred while fetching the plan");
+    return null;
+  }
+}
+
+export { getMyPlans, deletePlan, getPlan };

--- a/src/util/dashboard.js
+++ b/src/util/dashboard.js
@@ -81,4 +81,25 @@ const updatePlan = async (plan, onError) => {
   }
 };
 
-export { getMyPlans, deletePlan, getPlan, updatePlan };
+const getCategories = async (onError) => {
+  try {
+    let res = await fetch("/api/v1/account/categories", {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      }
+    });
+    if (!res.ok) {
+      const errorData = await res.json();
+      onError(errorData.msg || "Failed to fetch categories");
+      return null;
+    }
+    return await res.json();
+  }
+  catch (error) {
+    onError(error.message || "An error occurred while fetching categories");
+    return null;
+  }
+}
+
+export { getMyPlans, deletePlan, getPlan, updatePlan, getCategories };

--- a/src/util/dashboard.js
+++ b/src/util/dashboard.js
@@ -57,7 +57,7 @@ const getPlan = async (planId, onError) => {
     onError(error.message || "An error occurred while fetching the plan");
     return null;
   }
-}
+};
 
 const updatePlan = async (plan, onError) => {
   try {
@@ -79,6 +79,6 @@ const updatePlan = async (plan, onError) => {
     onError(error.message || "An error occurred while updating the plan");
     return null;
   }
-}
+};
 
 export { getMyPlans, deletePlan, getPlan, updatePlan };

--- a/src/util/dashboard.js
+++ b/src/util/dashboard.js
@@ -59,4 +59,26 @@ const getPlan = async (planId, onError) => {
   }
 }
 
-export { getMyPlans, deletePlan, getPlan };
+const updatePlan = async (plan, onError) => {
+  try {
+    let res = await fetch(`/api/v1/account/plans/${plan._id}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(plan),
+    });
+    if (!res.ok) {
+      const errorData = await res.json();
+      onError(errorData.msg || "Failed to update plan");
+      return null;
+    }
+    return await res.json();
+  } catch (error) {
+    onError(error.message || "An error occurred while updating the plan");
+    return null;
+  }
+}
+
+export { getMyPlans, deletePlan, getPlan, updatePlan };


### PR DESCRIPTION
## Description

Implemented edit functionality to plans, so user could open a plan as editable and update it.

## Testing Instructions

To test out the dashboard, you need to be logged-in, as we don't have the login yet, we can bypass the login process as follow:

1. Run backend server `npm run dev`
2. Open `http://localhost:8000/api-docs` in your browser
3. Find and execute the login endpoints `/auth/login` by putting my email (r.zahedi@gmail.com) and password (Reza4231) in the request body
4. Then grab the returned `token` in response body section
5. In frontend repo, add `localStorage.setItem("token", "<copy-token-here>")` to somewhere in `/src/app.js`
6. Open `http://localhost:5173/account` if you see `No plans found.` refresh the page and you should be able to see a list of plans with edit and delete buttons.
