### PR TITLE
Extend Create-New-Plan & Edit-Plan Form

### DIFF
--- a/src/Components/Pages/dashboard/CreateNew.jsx
+++ b/src/Components/Pages/dashboard/CreateNew.jsx
@@ -13,9 +13,9 @@ import {
 import { getCategories, createPlan } from "../../../util/dashboard";
 import { useAuth } from "../../../context/AuthContext";
 import PlanImages from "./components/PlanImages";
-import Stops from "./components/Stops"
+import Stops from "./components/Stops";
 
-const TYPES = ['Full day', 'Half day', 'Night']
+const TYPES = ["Full day", "Half day", "Night"];
 
 function CreateNew() {
   const [plan, setPlan] = useState({});
@@ -72,7 +72,10 @@ function CreateNew() {
           </FormControl>
 
           {/* Image */}
-          <PlanImages images={plan.images || []} setImages={(images)=> setPlan({ ...plan, images })} />
+          <PlanImages
+            images={plan.images || []}
+            setImages={(images) => setPlan({ ...plan, images })}
+          />
 
           {/* Category */}
           <FormControl fullWidth margin="normal">
@@ -153,7 +156,7 @@ function CreateNew() {
             {/* Duration */}
             <FormControl fullWidth margin="normal">
               <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
-              Duration
+                Duration
               </FormLabel>
               <TextField
                 variant="outlined"
@@ -167,7 +170,10 @@ function CreateNew() {
           </Box>
 
           {/* Stops */}
-          <Stops stops={plan.stops || []} setStops={(stops)=> setPlan({ ...plan, stops })} />
+          <Stops
+            stops={plan.stops || []}
+            setStops={(stops) => setPlan({ ...plan, stops })}
+          />
 
           <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
             <Button

--- a/src/Components/Pages/dashboard/CreateNew.jsx
+++ b/src/Components/Pages/dashboard/CreateNew.jsx
@@ -24,7 +24,7 @@ function CreateNew() {
   const navigate = useNavigate();
   const { token, user } = useAuth();
 
-  // TODO: Create the Add images and add stops components to allow users to add images and stops to their plans.
+  // TODO: Switch image URLs with actual multiple image upload feature.
 
   useEffect(() => {
     // FIXME: Instead of just redirecting user to home, show a not authorized message with login button or redirect to login page
@@ -42,7 +42,18 @@ function CreateNew() {
 
   const handleCreate = async (e) => {
     e.preventDefault();
-    const result = await createPlan(token, plan, setError);
+
+    // A random number with one decimal greater than 0 and less than 5
+    const rate = Math.round(Math.random() * 49 + 1) / 10;
+    // A random number between 0 and 100
+    const reviewCount = Math.floor(Math.random() * 100);
+    // Adding fake review data to the plan
+    const extendedPlan = {
+      ...plan,
+      rate,
+      reviewCount,
+    };
+    const result = await createPlan(token, extendedPlan, setError);
     if (!result) return;
 
     navigate("/account");

--- a/src/Components/Pages/dashboard/CreateNew.jsx
+++ b/src/Components/Pages/dashboard/CreateNew.jsx
@@ -13,6 +13,7 @@ import {
 import { getCategories, createPlan } from "../../../util/dashboard";
 import { useAuth } from "../../../context/AuthContext";
 import PlanImages from "./components/PlanImages";
+import Stops from "./components/Stops"
 
 const TYPES = ['Full day', 'Half day', 'Night']
 
@@ -164,6 +165,9 @@ function CreateNew() {
               />
             </FormControl>
           </Box>
+
+          {/* Stops */}
+          <Stops stops={plan.stops || []} setStops={(stops)=> setPlan({ ...plan, stops })} />
 
           <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
             <Button

--- a/src/Components/Pages/dashboard/CreateNew.jsx
+++ b/src/Components/Pages/dashboard/CreateNew.jsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import { getCategories, createPlan } from "../../../util/dashboard";
 import { useAuth } from "../../../context/AuthContext";
+import PlanImages from "./components/PlanImages";
 
 function CreateNew() {
   const [plan, setPlan] = useState({});
@@ -66,6 +67,9 @@ function CreateNew() {
               onChange={(e) => setPlan({ ...plan, title: e.target.value })}
             />
           </FormControl>
+
+          {/* Image */}
+          <PlanImages images={plan.images || []} setImages={(images)=> setPlan({ ...plan, images })} />
 
           {/* Category */}
           <FormControl fullWidth margin="normal">

--- a/src/Components/Pages/dashboard/CreateNew.jsx
+++ b/src/Components/Pages/dashboard/CreateNew.jsx
@@ -14,6 +14,8 @@ import { getCategories, createPlan } from "../../../util/dashboard";
 import { useAuth } from "../../../context/AuthContext";
 import PlanImages from "./components/PlanImages";
 
+const TYPES = ['Full day', 'Half day', 'Night']
+
 function CreateNew() {
   const [plan, setPlan] = useState({});
   const [categories, setCategories] = useState([]);
@@ -110,6 +112,59 @@ function CreateNew() {
               }
             />
           </FormControl>
+
+          {/* Type */}
+          <FormControl fullWidth margin="normal">
+            <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+              Type
+            </FormLabel>
+            <Select
+              variant="outlined"
+              fullWidth
+              value={plan.type || ""}
+              onChange={(e) => setPlan({ ...plan, type: e.target.value })}
+            >
+              <MenuItem value="">Select a plan type</MenuItem>
+              {TYPES.map((type, index) => (
+                <MenuItem key={index} value={type}>
+                  {type}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Box sx={{ display: "flex", flexDirection: "row", gap: 2 }}>
+            {/* Distance */}
+            <FormControl fullWidth margin="normal">
+              <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+                Distance
+              </FormLabel>
+              <TextField
+                variant="outlined"
+                fullWidth
+                placeholder="Distance in miles"
+                type="number"
+                value={plan.distance || ""}
+                onChange={(e) => setPlan({ ...plan, distance: e.target.value })}
+              />
+            </FormControl>
+
+            {/* Duration */}
+            <FormControl fullWidth margin="normal">
+              <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+              Duration
+              </FormLabel>
+              <TextField
+                variant="outlined"
+                fullWidth
+                placeholder="Duration in hours"
+                type="number"
+                value={plan.duration || ""}
+                onChange={(e) => setPlan({ ...plan, duration: e.target.value })}
+              />
+            </FormControl>
+          </Box>
+
           <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
             <Button
               variant="outlined"

--- a/src/Components/Pages/dashboard/EditPlan.jsx
+++ b/src/Components/Pages/dashboard/EditPlan.jsx
@@ -12,6 +12,10 @@ import {
 } from "@mui/material";
 import { getPlan, updatePlan, getCategories } from "../../../util/dashboard";
 import { useAuth } from "../../../context/AuthContext";
+import PlanImages from "./components/PlanImages";
+import Stops from "./components/Stops";
+
+const TYPES = ["Full day", "Half day", "Night"];
 
 function EditPlan() {
   const [plan, setPlan] = useState({});
@@ -83,6 +87,12 @@ function EditPlan() {
             />
           </FormControl>
 
+          {/* Image */}
+          <PlanImages
+            images={plan.images || []}
+            setImages={(images) => setPlan({ ...plan, images })}
+          />
+
           {/* Category */}
           {/* TODO: Replace it with a select dropdown */}
           <FormControl fullWidth margin="normal">
@@ -123,6 +133,65 @@ function EditPlan() {
               }
             />
           </FormControl>
+
+          {/* Type */}
+          <FormControl fullWidth margin="normal">
+            <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+              Type
+            </FormLabel>
+            <Select
+              variant="outlined"
+              fullWidth
+              value={plan.type || ""}
+              onChange={(e) => setPlan({ ...plan, type: e.target.value })}
+            >
+              <MenuItem value="">Select a plan type</MenuItem>
+              {TYPES.map((type, index) => (
+                <MenuItem key={index} value={type}>
+                  {type}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+
+          <Box sx={{ display: "flex", flexDirection: "row", gap: 2 }}>
+            {/* Distance */}
+            <FormControl fullWidth margin="normal">
+              <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+                Distance
+              </FormLabel>
+              <TextField
+                variant="outlined"
+                fullWidth
+                placeholder="Distance in miles"
+                type="number"
+                value={plan.distance || ""}
+                onChange={(e) => setPlan({ ...plan, distance: e.target.value })}
+              />
+            </FormControl>
+
+            {/* Duration */}
+            <FormControl fullWidth margin="normal">
+              <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+                Duration
+              </FormLabel>
+              <TextField
+                variant="outlined"
+                fullWidth
+                placeholder="Duration in hours"
+                type="number"
+                value={plan.duration || ""}
+                onChange={(e) => setPlan({ ...plan, duration: e.target.value })}
+              />
+            </FormControl>
+          </Box>
+
+          {/* Stops */}
+          <Stops
+            stops={plan.stops || []}
+            setStops={(stops) => setPlan({ ...plan, stops })}
+          />
+
           <Box sx={{ display: "flex", justifyContent: "flex-end", gap: 2 }}>
             <Button
               variant="outlined"

--- a/src/Components/Pages/dashboard/components/PlanImages.jsx
+++ b/src/Components/Pages/dashboard/components/PlanImages.jsx
@@ -1,5 +1,5 @@
-import React, { useRef } from 'react';
-import PropTypes from 'prop-types';
+import React, { useRef } from "react";
+import PropTypes from "prop-types";
 import {
   Box,
   FormControl,
@@ -7,8 +7,8 @@ import {
   TextField,
   IconButton,
 } from "@mui/material";
-import AddOutlinedIcon from '@mui/icons-material/AddOutlined';
-import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
+import AddOutlinedIcon from "@mui/icons-material/AddOutlined";
+import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 
 const PlanImages = ({ images, setImages }) => {
   const inputRef = useRef(null);
@@ -17,7 +17,7 @@ const PlanImages = ({ images, setImages }) => {
     if (!inputRef) return;
 
     setImages([...images, inputRef.current.value]);
-    inputRef.current.value = '';
+    inputRef.current.value = "";
     inputRef.current.focus();
   };
 
@@ -25,14 +25,14 @@ const PlanImages = ({ images, setImages }) => {
     const newImages = [...images];
     newImages.splice(imageIndex, 1);
     setImages(newImages);
-  }
+  };
 
   const handleImageChange = (event) => {
     const index = Number(event.target.dataset.index);
     const newImages = [...images];
     newImages[index] = event.target.value;
     setImages(newImages);
-  }
+  };
 
   return (
     <FormControl fullWidth margin="normal">
@@ -41,17 +41,23 @@ const PlanImages = ({ images, setImages }) => {
       </FormLabel>
       <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
         {images.map((image, index) => (
-          <Box key={index} sx={{ display: "flex", alignItems: "flex-end", gap: 1 }}>
+          <Box
+            key={index}
+            sx={{ display: "flex", alignItems: "flex-end", gap: 1 }}
+          >
             <TextField
               required
               variant="outlined"
               fullWidth
               placeholder="Enter the full image URL"
               value={image}
-              inputProps={{ 'data-index': index }}
+              inputProps={{ "data-index": index }}
               onChange={handleImageChange}
             />
-            <IconButton aria-label="Remove Image" onClick={() => handleDeleteImage(index)}>
+            <IconButton
+              aria-label="Remove Image"
+              onClick={() => handleDeleteImage(index)}
+            >
               <DeleteOutlineOutlinedIcon />
             </IconButton>
           </Box>
@@ -70,7 +76,7 @@ const PlanImages = ({ images, setImages }) => {
         </Box>
       </Box>
     </FormControl>
-  )
+  );
 };
 
 PlanImages.propTypes = {

--- a/src/Components/Pages/dashboard/components/PlanImages.jsx
+++ b/src/Components/Pages/dashboard/components/PlanImages.jsx
@@ -1,0 +1,72 @@
+import React, { useRef } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Box,
+  FormControl,
+  FormLabel,
+  TextField,
+  IconButton,
+} from "@mui/material";
+import AddOutlinedIcon from '@mui/icons-material/AddOutlined';
+import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
+
+const PlanImages = ({ images, setImages }) => {
+  const inputRef = useRef(null);
+
+  const handleAddImage = () => {
+    if (!inputRef) return;
+
+    setImages([...images, inputRef.current.value]);
+    inputRef.current.value = '';
+    inputRef.current.focus();
+  };
+
+  const handleDeleteImage = (imageIndex) => {
+    const newImages = [...images];
+    newImages.splice(imageIndex, 1);
+    setImages(newImages);
+  }
+
+  return (
+    <FormControl fullWidth margin="normal">
+      <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+        Images *
+      </FormLabel>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
+        {images.map((image, index) => (
+          <Box key={index} sx={{ display: "flex", alignItems: "flex-end", gap: 1 }}>
+            <TextField
+              required
+              variant="outlined"
+              fullWidth
+              placeholder="Enter the full image URL"
+              value={image}
+            />
+            <IconButton aria-label="Remove Image" onClick={() => handleDeleteImage(index)}>
+              <DeleteOutlineOutlinedIcon />
+            </IconButton>
+          </Box>
+        ))}
+        <Box sx={{ display: "flex", alignItems: "flex-end", gap: 1 }}>
+          <TextField
+            inputRef={inputRef}
+            required={images.length === 0}
+            variant="outlined"
+            fullWidth
+            placeholder="Enter the full image URL"
+          />
+          <IconButton aria-label="Add Image" onClick={handleAddImage}>
+            <AddOutlinedIcon />
+          </IconButton>
+        </Box>
+      </Box>
+    </FormControl>
+  )
+};
+
+PlanImages.propTypes = {
+  images: PropTypes.arrayOf(PropTypes.string).isRequired,
+  setImages: PropTypes.func.isRequired,
+};
+
+export default PlanImages;

--- a/src/Components/Pages/dashboard/components/PlanImages.jsx
+++ b/src/Components/Pages/dashboard/components/PlanImages.jsx
@@ -27,6 +27,13 @@ const PlanImages = ({ images, setImages }) => {
     setImages(newImages);
   }
 
+  const handleImageChange = (event) => {
+    const index = Number(event.target.dataset.index);
+    const newImages = [...images];
+    newImages[index] = event.target.value;
+    setImages(newImages);
+  }
+
   return (
     <FormControl fullWidth margin="normal">
       <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
@@ -41,6 +48,8 @@ const PlanImages = ({ images, setImages }) => {
               fullWidth
               placeholder="Enter the full image URL"
               value={image}
+              inputProps={{ 'data-index': index }}
+              onChange={handleImageChange}
             />
             <IconButton aria-label="Remove Image" onClick={() => handleDeleteImage(index)}>
               <DeleteOutlineOutlinedIcon />

--- a/src/Components/Pages/dashboard/components/Stops.jsx
+++ b/src/Components/Pages/dashboard/components/Stops.jsx
@@ -38,6 +38,14 @@ const Stops = ({ stops, setStops }) => {
     setStops(newStops);
   }
 
+  const handleStopChange = (event) => {
+    const index = Number(event.target.dataset.index);
+    const type = event.target.dataset.type;
+    const newStops = [...stops];
+    newStops[index][type] = event.target.value;
+    setStops(newStops);
+  }
+
   return (
     <FormControl fullWidth margin="normal">
       <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
@@ -54,6 +62,8 @@ const Stops = ({ stops, setStops }) => {
                 fullWidth
                 placeholder="Enter the name"
                 value={stop.name}
+                inputProps={{ 'data-index': index, 'data-type': 'name' }}
+                onChange={handleStopChange}
                 sx={{ "& input": {background:'white', padding:'6px 12px'}}}
               />
               <TextField
@@ -62,6 +72,8 @@ const Stops = ({ stops, setStops }) => {
                 fullWidth
                 placeholder="Enter the image URL"
                 value={stop.imageURL}
+                inputProps={{ 'data-index': index, 'data-type': 'imageURL' }}
+                onChange={handleStopChange}
                 sx={{ "& input": {background:'white', padding:'6px 12px'}}}
               />
               <TextField
@@ -70,6 +82,8 @@ const Stops = ({ stops, setStops }) => {
                 fullWidth
                 placeholder="Enter the address"
                 value={stop.address}
+                inputProps={{ 'data-index': index, 'data-type': 'address' }}
+                onChange={handleStopChange}
                 sx={{ "& input": {background:'white', padding:'6px 12px'}}}
               />
             </Box>

--- a/src/Components/Pages/dashboard/components/Stops.jsx
+++ b/src/Components/Pages/dashboard/components/Stops.jsx
@@ -1,5 +1,5 @@
-import React, { useRef } from 'react';
-import PropTypes from 'prop-types';
+import React, { useRef } from "react";
+import PropTypes from "prop-types";
 import {
   Box,
   FormControl,
@@ -8,8 +8,7 @@ import {
   IconButton,
   Button,
 } from "@mui/material";
-import AddOutlinedIcon from '@mui/icons-material/AddOutlined';
-import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
+import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 
 const Stops = ({ stops, setStops }) => {
   const nameRef = useRef(null);
@@ -23,12 +22,12 @@ const Stops = ({ stops, setStops }) => {
       name: nameRef.current.value,
       imageURL: imageRef.current.value,
       address: addressRef.current.value,
-    }
+    };
 
     setStops([...stops, currentStop]);
-    nameRef.current.value = '';
-    imageRef.current.value = '';
-    addressRef.current.value = '';
+    nameRef.current.value = "";
+    imageRef.current.value = "";
+    addressRef.current.value = "";
     nameRef.current.focus();
   };
 
@@ -36,7 +35,7 @@ const Stops = ({ stops, setStops }) => {
     const newStops = [...stops];
     newStops.splice(stopIndex, 1);
     setStops(newStops);
-  }
+  };
 
   const handleStopChange = (event) => {
     const index = Number(event.target.dataset.index);
@@ -44,7 +43,7 @@ const Stops = ({ stops, setStops }) => {
     const newStops = [...stops];
     newStops[index][type] = event.target.value;
     setStops(newStops);
-  }
+  };
 
   return (
     <FormControl fullWidth margin="normal">
@@ -53,18 +52,39 @@ const Stops = ({ stops, setStops }) => {
       </FormLabel>
       <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
         {stops.map((stop, index) => (
-          <Box key={index} sx={{ display: "flex", alignItems: "center", gap: 1, backgroundColor: "#f5f5f5", borderRadius: 2, padding: 2 }}>
-            <img src={stop.imageURL} alt={stop.name} style={{ width: "100px", height: "100px" }} />
-            <Box sx={{ flexGrow: 1, display: "flex", flexDirection: "column", gap: 0.5 }}>
+          <Box
+            key={index}
+            sx={{
+              display: "flex",
+              alignItems: "center",
+              gap: 1,
+              backgroundColor: "#f5f5f5",
+              borderRadius: 2,
+              padding: 2,
+            }}
+          >
+            <img
+              src={stop.imageURL}
+              alt={stop.name}
+              style={{ width: "100px", height: "100px" }}
+            />
+            <Box
+              sx={{
+                flexGrow: 1,
+                display: "flex",
+                flexDirection: "column",
+                gap: 0.5,
+              }}
+            >
               <TextField
                 required
                 variant="outlined"
                 fullWidth
                 placeholder="Enter the name"
                 value={stop.name}
-                inputProps={{ 'data-index': index, 'data-type': 'name' }}
+                inputProps={{ "data-index": index, "data-type": "name" }}
                 onChange={handleStopChange}
-                sx={{ "& input": {background:'white', padding:'6px 12px'}}}
+                sx={{ "& input": { background: "white", padding: "6px 12px" } }}
               />
               <TextField
                 required
@@ -72,9 +92,9 @@ const Stops = ({ stops, setStops }) => {
                 fullWidth
                 placeholder="Enter the image URL"
                 value={stop.imageURL}
-                inputProps={{ 'data-index': index, 'data-type': 'imageURL' }}
+                inputProps={{ "data-index": index, "data-type": "imageURL" }}
                 onChange={handleStopChange}
-                sx={{ "& input": {background:'white', padding:'6px 12px'}}}
+                sx={{ "& input": { background: "white", padding: "6px 12px" } }}
               />
               <TextField
                 required
@@ -82,24 +102,37 @@ const Stops = ({ stops, setStops }) => {
                 fullWidth
                 placeholder="Enter the address"
                 value={stop.address}
-                inputProps={{ 'data-index': index, 'data-type': 'address' }}
+                inputProps={{ "data-index": index, "data-type": "address" }}
                 onChange={handleStopChange}
-                sx={{ "& input": {background:'white', padding:'6px 12px'}}}
+                sx={{ "& input": { background: "white", padding: "6px 12px" } }}
               />
             </Box>
-            <IconButton aria-label="Remove Stop" onClick={() => handleDeleteStop(index)}>
+            <IconButton
+              aria-label="Remove Stop"
+              onClick={() => handleDeleteStop(index)}
+            >
               <DeleteOutlineOutlinedIcon />
             </IconButton>
           </Box>
         ))}
-        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 0.5, backgroundColor: "#f5f5f5", borderRadius: 2, padding: 2 }}>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-end",
+            gap: 0.5,
+            backgroundColor: "#f5f5f5",
+            borderRadius: 2,
+            padding: 2,
+          }}
+        >
           <TextField
             inputRef={nameRef}
             required={stops.length === 0}
             variant="outlined"
             fullWidth
             placeholder="Enter the name"
-            sx={{ "& input": {background:'white'}}}
+            sx={{ "& input": { background: "white" } }}
           />
           <TextField
             inputRef={imageRef}
@@ -107,7 +140,7 @@ const Stops = ({ stops, setStops }) => {
             variant="outlined"
             fullWidth
             placeholder="Enter the image URL"
-            sx={{ "& input": {background:'white'}}}
+            sx={{ "& input": { background: "white" } }}
           />
           <TextField
             inputRef={addressRef}
@@ -115,13 +148,15 @@ const Stops = ({ stops, setStops }) => {
             variant="outlined"
             fullWidth
             placeholder="Enter the address"
-            sx={{ "& input": {background:'white'}}}
+            sx={{ "& input": { background: "white" } }}
           />
-          <Button aria-label="Add Stop" onClick={handleAddStop}>Add Stop</Button>
+          <Button aria-label="Add Stop" onClick={handleAddStop}>
+            Add Stop
+          </Button>
         </Box>
       </Box>
     </FormControl>
-  )
+  );
 };
 
 Stops.propTypes = {

--- a/src/Components/Pages/dashboard/components/Stops.jsx
+++ b/src/Components/Pages/dashboard/components/Stops.jsx
@@ -1,0 +1,118 @@
+import React, { useRef } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Box,
+  FormControl,
+  FormLabel,
+  TextField,
+  IconButton,
+  Button,
+} from "@mui/material";
+import AddOutlinedIcon from '@mui/icons-material/AddOutlined';
+import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
+
+const Stops = ({ stops, setStops }) => {
+  const nameRef = useRef(null);
+  const imageRef = useRef(null);
+  const addressRef = useRef(null);
+
+  const handleAddStop = () => {
+    if (!nameRef || !imageRef || !addressRef) return;
+
+    const currentStop = {
+      name: nameRef.current.value,
+      imageURL: imageRef.current.value,
+      address: addressRef.current.value,
+    }
+
+    setStops([...stops, currentStop]);
+    nameRef.current.value = '';
+    imageRef.current.value = '';
+    addressRef.current.value = '';
+    nameRef.current.focus();
+  };
+
+  const handleDeleteStop = (stopIndex) => {
+    const newStops = [...stops];
+    newStops.splice(stopIndex, 1);
+    setStops(newStops);
+  }
+
+  return (
+    <FormControl fullWidth margin="normal">
+      <FormLabel sx={{ fontWeight: "bold", mb: 1, color: "#000" }}>
+        Stops *
+      </FormLabel>
+      <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+        {stops.map((stop, index) => (
+          <Box key={index} sx={{ display: "flex", alignItems: "center", gap: 1, backgroundColor: "#f5f5f5", borderRadius: 2, padding: 2 }}>
+            <img src={stop.imageURL} alt={stop.name} style={{ width: "100px", height: "100px" }} />
+            <Box sx={{ flexGrow: 1, display: "flex", flexDirection: "column", gap: 0.5 }}>
+              <TextField
+                required
+                variant="outlined"
+                fullWidth
+                placeholder="Enter the name"
+                value={stop.name}
+                sx={{ "& input": {background:'white', padding:'6px 12px'}}}
+              />
+              <TextField
+                required
+                variant="outlined"
+                fullWidth
+                placeholder="Enter the image URL"
+                value={stop.imageURL}
+                sx={{ "& input": {background:'white', padding:'6px 12px'}}}
+              />
+              <TextField
+                required
+                variant="outlined"
+                fullWidth
+                placeholder="Enter the address"
+                value={stop.address}
+                sx={{ "& input": {background:'white', padding:'6px 12px'}}}
+              />
+            </Box>
+            <IconButton aria-label="Remove Stop" onClick={() => handleDeleteStop(index)}>
+              <DeleteOutlineOutlinedIcon />
+            </IconButton>
+          </Box>
+        ))}
+        <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 0.5, backgroundColor: "#f5f5f5", borderRadius: 2, padding: 2 }}>
+          <TextField
+            inputRef={nameRef}
+            required={stops.length === 0}
+            variant="outlined"
+            fullWidth
+            placeholder="Enter the name"
+            sx={{ "& input": {background:'white'}}}
+          />
+          <TextField
+            inputRef={imageRef}
+            required={stops.length === 0}
+            variant="outlined"
+            fullWidth
+            placeholder="Enter the image URL"
+            sx={{ "& input": {background:'white'}}}
+          />
+          <TextField
+            inputRef={addressRef}
+            required={stops.length === 0}
+            variant="outlined"
+            fullWidth
+            placeholder="Enter the address"
+            sx={{ "& input": {background:'white'}}}
+          />
+          <Button aria-label="Add Stop" onClick={handleAddStop}>Add Stop</Button>
+        </Box>
+      </Box>
+    </FormControl>
+  )
+};
+
+Stops.propTypes = {
+  stops: PropTypes.arrayOf(PropTypes.object).isRequired,
+  setStops: PropTypes.func.isRequired,
+};
+
+export default Stops;


### PR DESCRIPTION
## Description

1. Extend Create-New form to have all the inputs including multi-images, meta-data inputs and stops.
2. Create two new components one for multi-images and the other one for adding stops.
2. Extend edit-plan form to have ability to edit all the meta-data, plan's images, stops

## Related Issue

In previous version we couldn't add plans's details or edit, mainly images and stops. With this new update we could add/edit details of our plans and make them data-reach and also give us more control over data.

## Type of Changes

Feature update: create-new-plan and edit-plan forms extended with more inputs.

## Update Screenshots

### After

![Screenshot 2025-05-01 232437](https://github.com/user-attachments/assets/86b40619-f848-45ea-a7c6-a91e1ff20809)
![Screenshot 2025-05-01 232451](https://github.com/user-attachments/assets/2b925a57-ea8f-4741-9b6f-ebccc3fb0e2f)


## Testing Instructions

Add as many image URLs or stops as you want, as inputs are controlled you could change the values or even delete one.
