### PR TITLE
Remove .env file from git

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-VITE_API_BASE_URL=http://localhost:8000


### PR DESCRIPTION
## Related Issue

The `.env` file was gotten into git, even though its name was already listed in `.gitignore`. I removed it from the repository using `git rm --cached .env` to ensure it won’t be tracked by Git going forward after it.