### PR TITLE
Use Token on Public Routes

### DIFF
--- a/src/Components/Common/CardSection.jsx
+++ b/src/Components/Common/CardSection.jsx
@@ -2,16 +2,14 @@ import React, { useState, useEffect } from "react";
 import { Grid, Box, Typography } from "@mui/material";
 import PropTypes from "prop-types";
 import PlanCard from "./PlanCard";
-import { getBookmarks } from "../../util/dashboard";
 import { useAuth } from "../../context/AuthContext";
 import PlanCardSkeleton from "./PlanCardSkeleton";
-import { getData } from "../../util";
+import { fetchPlans } from "../../util";
 
 const CardSection = ({ title, category = "", search = "", size = 4 }) => {
   const { token } = useAuth();
   const [plans, setPlans] = useState([]);
   const [loading, setLoading] = useState(true);
-  const URL = `${import.meta.env.VITE_API_BASE_URL}/api/v1/plans?categoryId=${category}&search=${search}&size=${size}`;
 
   const setError = (errorMessage) => {
     console.log("error", errorMessage);
@@ -22,39 +20,16 @@ const CardSection = ({ title, category = "", search = "", size = 4 }) => {
   useEffect(() => {
     const fetchAllPlans = async () => {
       try {
-        const result = await getData(URL);
+        const result = await fetchPlans(
+          `plans?categoryId=${category}&search=${search}&size=${size}`,
+          token,
+          setError,
+        );
+        setLoading(false);
 
         if (!result || !result.items) return;
 
-        let fetchedPlans = result.items;
-
-        if (token) {
-          const fetchedBookmarks = await getBookmarks(token, setError);
-          if (fetchedBookmarks && fetchedBookmarks.items.length > 0) {
-            const bookmarksIds = fetchedBookmarks.items.map((item) => item._id);
-
-            setPlans(
-              fetchedPlans.map((plan) => {
-                return {
-                  ...plan,
-                  isBookmarked: bookmarksIds.includes(plan._id),
-                };
-              }),
-            );
-          } else {
-            setPlans(fetchedPlans);
-          }
-        } else {
-          setPlans(
-            fetchedPlans.map((plan) => {
-              return {
-                ...plan,
-                isBookmarked: false,
-              };
-            }),
-          );
-        }
-        setLoading(false);
+        setPlans(result.items);
       } catch (error) {
         console.log("Error fetching data:", error);
       }

--- a/src/Components/Common/CardSection.jsx
+++ b/src/Components/Common/CardSection.jsx
@@ -22,11 +22,8 @@ const CardSection = ({ title, category = "", search = "", size = 4 }) => {
           token,
           setError,
         );
+        setPlans(result?.items || []);
         setLoading(false);
-
-        if (!result || !result.items) return;
-
-        setPlans(result.items);
       } catch (error) {
         console.log("Error fetching data:", error);
       }

--- a/src/Components/Common/CardSection.jsx
+++ b/src/Components/Common/CardSection.jsx
@@ -10,10 +10,7 @@ const CardSection = ({ title, category = "", search = "", size = 4 }) => {
   const { token } = useAuth();
   const [plans, setPlans] = useState([]);
   const [loading, setLoading] = useState(true);
-
-  const setError = (errorMessage) => {
-    console.log("error", errorMessage);
-  };
+  const [error, setError] = useState(null);
 
   // TODO: Add skeleton loading feature later
 
@@ -59,6 +56,7 @@ const CardSection = ({ title, category = "", search = "", size = 4 }) => {
         }}
       >
         <Grid container spacing={3} sx={{ width: "100%" }}>
+          {!loading && error && <p>{error}</p>}
           {loading &&
             Array.from({ length: 4 }).map((_, index) => (
               <Grid size={{ xs: 12, sm: 6, md: 3 }} key={index}>

--- a/src/Components/Pages/SearchPage.jsx
+++ b/src/Components/Pages/SearchPage.jsx
@@ -3,14 +3,13 @@ import { useLocation } from "react-router-dom";
 import { getQueryValue } from "../../util/url";
 import { Box, Typography, Grid } from "@mui/material";
 import PlanCard from "../Common/PlanCard";
-import { getData } from "../../util";
+import { fetchPlans } from "../../util";
 import WelcomeMessage from "../Common/search/WelcomeMessage";
 import EmptyResultMessage from "../Common/search/EmptyResultMessage";
 import Pagination from "../Common/Pagination";
+import { useAuth } from "../../context/AuthContext";
 
 const PAGE_SIZE = 8;
-
-const API_URL = `${import.meta.env.VITE_API_BASE_URL}/api/v1/plans`;
 
 const SearchPage = () => {
   const location = useLocation();
@@ -21,6 +20,8 @@ const SearchPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [plans, setPlans] = useState([]);
   const [pagesCount, setPagesCount] = useState(0);
+  const [error, setError] = useState(null);
+  const { token } = useAuth();
 
   useEffect(() => {
     page = getQueryValue(location.search, "page") || "1";
@@ -36,7 +37,7 @@ const SearchPage = () => {
       const paramsString = params.toString();
 
       try {
-        const res = await getData(`${API_URL}?${paramsString}`);
+        const res = await fetchPlans(`plans?${paramsString}`, token, setError);
         setPlans(res?.items || []);
         setPagesCount(res?.pagesCount || 0);
         setIsLoading(false);
@@ -71,6 +72,7 @@ const SearchPage = () => {
           gap: "16px",
         }}
       >
+        {!isLoading && error && <p>{error}</p>}
         {isLoading && <>Loading ...</>}
         {plans.length > 0 && (
           <>

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,5 +1,7 @@
 import axios from "axios";
 
+const API_V1_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}/api/v1`;
+
 // Fetch data with query parameters
 const getData = async (url, params = {}) => {
   try {
@@ -40,4 +42,25 @@ const postData = async (url, requestBody = {}, config = {}) => {
   }
 };
 
-export { getData, getAllData, postData };
+const fetchPlans = async (endpoint, token = "", onError) => {
+  try {
+    let res = await fetch(`${API_V1_BASE_URL}/${endpoint}`, {
+      ...(token && {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+    });
+    if (!res.ok) {
+      const errorData = await res.json();
+      onError(errorData.msg || "Failed to fetch plans");
+      return null;
+    }
+    return await res.json();
+  } catch (error) {
+    onError(error.message || "An error occurred while fetching plans");
+    return null;
+  }
+};
+
+export { getData, getAllData, postData, fetchPlans };


### PR DESCRIPTION
## Description

1. In a logged-in situation use token on `api/v1/plans` public endpoints to return user-specific data.
2. Return plans with the bookmark state (true or false)

## Related Issue

Previously, I handled displaying bookmarked plans on the homepage using two API calls: first to fetch all plans, and then another to fetch the IDs of the user's bookmarked plans. I know, it was a dump approach, but I thought it would be a quick solution. Eventually, I ended up modifying the `api/v1/plans` backend API to accept a optional Bearer token and return plans along with their bookmark status. That change made things much simpler on the frontend.

## Acceptance Criteria

Nothing changed on frontend UI, bookmark buttons should work as before.

## Testing Instructions

- Switch branch on your backend clone to `token-in-public-routes` from [PR #63](https://github.com/Code-the-Dream-School/ii-practicum-team-5-back/pull/63) then run the server.
- Run frontend server, open homepage, login and try to bookmark few plans in homepage or in search result page.
- Logout and login again, bookmarked plans should stay the same with a yellow bookmark icon.
